### PR TITLE
FIX: newer LaTeX graphics require matching caps

### DIFF
--- a/handout/handout.tex
+++ b/handout/handout.tex
@@ -89,7 +89,7 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
   \begin{marginfigure}[-1.7cm]%
     \centering%
     \begingroup
-      \vcenteredhbox{\includegraphics[height=0.59cm]{GitHub-Mark-large.png}}%
+      \vcenteredhbox{\includegraphics[height=0.59cm]{GitHub-Mark-Large.png}}%
       \vcenteredhbox{\includegraphics[height=1cm]{GitHub-Logo.png}}%
     \endgroup
     \label{fig:GitHub}%


### PR DESCRIPTION
Figure capitalization now must exactly match the graphics files.

This fix makes the 2015 handout buildable again without errors.  Updating further based off of this branch.