### PR TITLE
UPDATE: skimage 0.14, SciPy 2018 tutorial

### DIFF
--- a/handout/handout.tex
+++ b/handout/handout.tex
@@ -8,7 +8,7 @@
 % -------------------------------------------------------------------------- %
 % Define document-specific macros here
 \newcommand{\release}{0.14\xspace} % Update with new version
-\DeclareRobustCommand{\ski}{\texttt{scikit-image}\xspace}
+\DeclareRobustCommand{\ski}{scikit-image\xspace}
 \DeclareRobustCommand{\spy}{SciPy\xspace} % Sadly, \sp is reserved (superscript)
 \DeclareRobustCommand{\np}{NumPy\xspace}
 \newcommand{\eg}{e.g.\xspace}
@@ -33,7 +33,7 @@
              top=1in,
              headsep=2\baselineskip,
              marginparsep=2pc,
-             textheight=45\baselineskip,
+             textheight=46\baselineskip,
              headheight=\baselineskip}
 
 
@@ -96,7 +96,7 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
   \end{marginfigure}%
   %
   \noindent
-  Interact with the community in the \ski Gitter chat room at \url{gitter.im/scikit-image/scikit-image} or post to the Google Group at \url{groups.google.com/forum/#!forum/scikit-image}.
+  Interact with the community in the \ski Gitter chat room at \url{gitter.im/scikit-image/scikit-image}, post/subscribe to the mailing list at \url{mail.python.org/mailman/listinfo/scikit-image}, or tag scikit-image on StackOverflow for assistance.
   % subsection additional_resources (end)
 
 \subsection{A humble request} % (fold)
@@ -105,11 +105,11 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
   % subsection a_humble_request (end)
 
 % -------------------------------------------------------------------------- %
-% Reverse side: Road map to the package
+% Reverse side: Guide to the package
 \newpage%
-\section{Road map to \ski} % (fold)
-  \label{sec:road_map}
-  Brief descriptions of every subpackage in \ski \release follow. Each subpackage contains algorithms used for similar purposes.\\
+\section{Guide to \ski} % (fold)
+  \label{sec:guide}
+  Brief descriptions of every subpackage in \ski \release follow. Each subpackage contains algorithms used for similar purposes. You can also search package docstrings with \textcolor{DarkBlue}{\texttt{skimage.lookfor}}.\\
 
   % Horizontal line
   \noindent%
@@ -160,9 +160,9 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
       \end{marginfigure}%
       %
       \item[hough_line] Find lines in an image\footnote[4][-0.7cm]{Hough transforms can detect lines (above), circles, or ellipses.}. Circle, ellipse also available.
+      \item[regionprops] Calculate many properties in a labeled image.
     \end{description}
     \item[skimage.morphology] Morphological operations, \eg, dilation and erosion. Binary and grayscale morphology supported.
-    \item[skimage.novice] Simplified teaching interface.
     \item[skimage.restoration] Remove noise or deconvolve images.
     \item[skimage.segmentation] Partition an image into multiple regions.
     \begin{description}

--- a/handout/handout.tex
+++ b/handout/handout.tex
@@ -7,7 +7,7 @@
 
 % -------------------------------------------------------------------------- %
 % Define document-specific macros here
-\newcommand{\release}{0.11.3\xspace} % Update with new version
+\newcommand{\release}{0.14\xspace} % Update with new version
 \DeclareRobustCommand{\ski}{\texttt{scikit-image}\xspace}
 \DeclareRobustCommand{\spy}{SciPy\xspace} % Sadly, \sp is reserved (superscript)
 \DeclareRobustCommand{\np}{NumPy\xspace}
@@ -22,7 +22,7 @@
 % Definitions used throughout the package
 \title{\ski: the image processing toolkit for \spy}
 \author[the \ski contributors]{the \ski contributors}
-\date{6 July 2015} % Specify date, or comment out to use current date
+\date{9 July 2018} % Specify date, or comment out to use current date
 
 
 % -------------------------------------------------------------------------- %
@@ -69,12 +69,12 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
     \label{fig:tux_inset}
   \end{marginfigure}
 
-  An image is simply a collection of data on a regular, two-dimensional grid. In \ski, we use \np arrays to represent images. Color images have more than one channel, \eg, red, green, and blue (\rgb). Thus, the \np array for a color image is \textit{three}-dimensional, with channel information in the final dimension.
+  An image is simply a collection of data on a regular, often two-dimensional grid. In \ski, we use \np arrays to represent images. Color images have more than one channel, \eg, red, green, and blue (\rgb). Thus, the \np array for a color image is \textit{three}-dimensional, with channel information in the final dimension.
   % subsection images_are_arrays (end)
 
 \subsection{Speak our language} % (fold)
   \label{sub:talking_our_language}
-  To avoid confusion, we refrain from using the terms \textit{x} or \textit{y}. Throughout the package, \ski refers to \textit{rows} (r) and \textit{columns} (c). When color data is present, \textit{channel} (ch) denotes the third dimension. \np arrays representing images are indexed via \pyv{arr[rows, columns]}.
+  To avoid confusion, we refrain from using the terms \textit{x} or \textit{y}. Throughout the package, \ski refers to \textit{rows} (r) and \textit{columns} (c). When color data is present, \textit{channel} (ch) denotes the third dimension. \np arrays representing 2D images are indexed via \pyv{arr[rows, columns]}.
   %
   \begin{marginfigure}[-1.1cm]%
     \includegraphics[width=\linewidth]{row-col.png}
@@ -132,7 +132,7 @@ Welcome to \ski! This handout is designed to supplement and enhance the \ski tut
     \end{description}
     \item[skimage.data] Test images.
     \begin{description}
-      \item[astronaut] Image of the astronaut Eileen Collins\footnote[2][-0.2cm]{The \textcolor{DarkBlue}{\texttt{astronaut}} test image. Please use this image in place of \textcolor{DarkBlue}{\texttt{lena}}.}.
+      \item[astronaut] Image of the astronaut Eileen Collins\footnote[2][-0.2cm]{The \textcolor{DarkBlue}{\texttt{astronaut}} test image, an excellent public domain test image.}.
     \end{description}
     \item[skimage.draw] Drawing primitives such as lines or text.
     \item[skimage.exposure] Intensity and contrast adjustments.


### PR DESCRIPTION
Relatively minor updates; the handout is still essentially entirely still relevant.

No major new subpackages have been added since 0.11.3, so the reverse side is still accurate; the `lena` image was removed so the astronaut caption is tweaked slightly.

See link below with the current state as of this PR.  See anything I missed, @stefanv or @jni?  Any other thoughts/opinions about which functions to call out on the reverse?

[handout.pdf](https://github.com/scikit-image/skimage-media/files/2168998/handout.pdf)
